### PR TITLE
fix: correct InspectGuest interface and remove render crash

### DIFF
--- a/src/components/Inspect.tsx
+++ b/src/components/Inspect.tsx
@@ -7,16 +7,19 @@ import apiClient from '@/utils/apiClient';
 import QrScanner from './QrScanner';
 
 interface InspectGuest {
+	id: string;
 	firstName: string;
 	lastName: string;
 	created: string;
-	createdReason: string;
+	createdReason?: string;
 	status: string;
 	orderId: string;
-	meta: { comment?: string };
 	admissionTier: string;
-	checkInTime: string;
+	checkInTime: string | null;
+	eventId: string;
 	eventName: string;
+	eventDate: string;
+	eventStatus: string;
 }
 
 const CheckIn = () => {
@@ -46,7 +49,7 @@ const CheckIn = () => {
 			});
 	}, []);
 
-	const { firstName, lastName, created, createdReason, status, orderId, meta, admissionTier, checkInTime, eventName } = guest || ({} as InspectGuest);
+	const { firstName, lastName, created, createdReason, status, orderId, admissionTier, checkInTime, eventName } = guest || ({} as InspectGuest);
 
 	return (
 		<div className={styles.inspect}>
@@ -80,10 +83,7 @@ const CheckIn = () => {
 						<span>Event:</span> {eventName}
 					</h3>
 					<h3>
-						<span>Status:</span> {status === 'checked_in' ? <>Checked In {format(new Date(checkInTime), 'M/dd/yy - HH:mm')}</> : status}
-					</h3>
-					<h3>
-						<span>Notes:</span> {meta?.comment || ' n/a '}
+						<span>Status:</span> {status === 'checked_in' && checkInTime ? <>Checked In {format(new Date(checkInTime), 'M/dd/yy - HH:mm')}</> : status}
 					</h3>
 
 					<h3>


### PR DESCRIPTION
## Summary
- Updated `InspectGuest` interface to accurately reflect the API response (added `id`, `eventId`, `eventDate`, `eventStatus`; made `createdReason` optional; typed `checkInTime` as `string | null`)
- Removed `meta: { comment?: string }` from the interface and destructuring (not returned by the API)
- Removed the Notes row that rendered `meta?.comment`
- Added `checkInTime` null guard before calling `format(new Date(checkInTime), ...)`

## Why
The Inspect page crashed on every QR scan. Root cause: `meta` and `created` were declared in the interface but `meta` was never returned by the API, so `meta?.comment` silently rendered nothing — but `created` being absent meant `format(new Date(undefined))` threw during render, propagating past the `.catch()` and hitting the ErrorBoundary.

Depends on mustachebash/api#121 which adds `created` to the `/v1/inspect` response.

## Test plan
- [ ] Scan a valid guest QR on the Inspect page — guest info renders correctly, no crash
- [ ] Checked-in guest shows check-in time; unchecked guest shows status string
- [ ] Scan an unknown QR — "Guest not found" message (no crash)
- [ ] `npm test` passes in `admin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)